### PR TITLE
Fixes & Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN make build
 
 FROM chianetwork/chia-docker:latest
 
+ENV service="node"
 COPY docker-start.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-start.sh
 COPY --from=builder /app/bin/block-metrics /block-metrics

--- a/internal/metrics/database.go
+++ b/internal/metrics/database.go
@@ -12,7 +12,7 @@ func (m *Metrics) initTables() error {
 		"  PRIMARY KEY (`id`)," +
 		"UNIQUE KEY `height-unique` (`height`)," +
 		"KEY `height` (`height`)" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 
 	result, err := m.mysqlClient.Query(query)
 	if err != nil {

--- a/k8s/internal.yaml.j2
+++ b/k8s/internal.yaml.j2
@@ -10,9 +10,10 @@ deployment:
   environment:
     CHIA_ROOT: /chia-data
   livenessProbe:
-    httpGet:
-      path: /healthz
-      port: http
+    exec:
+      command:
+        - bash
+        - /usr/local/bin/docker-healthcheck.sh
   readinessProbe:
     httpGet:
       path: /healthz

--- a/k8s/pub-metrics.yaml.j2
+++ b/k8s/pub-metrics.yaml.j2
@@ -21,7 +21,7 @@ deployment:
 service:
   enabled: true
   additionalLabels:
-    #prometheus: application-metrics
+    prometheus: application-metrics
     application: block-metrics
   port: 9914
 


### PR DESCRIPTION
* Only run `node` service
* Use `utf8mb4_general_ci` for compatibility with older MySQL versions
* Ensure there are 32256 blocks in the lookback window before trusting the math (mostly protects against cases when the DB is new and syncing blocks)
* Use the `docker-healthcheck.sh` script as a liveness probe so we can catch the rare case where daemon doesn't start properly
* Reenables the label for prom to scrape the metrics